### PR TITLE
feat: add booking API endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from routes.admin_bp import admin_bp
 from routes.task_bp import task_bp
 from routes.public_bp import public_bp
 from routes.schedule_bp import schedule_bp
+from routes.booking_api import booking_api
 import json
 from jinja2 import ChoiceLoader, FileSystemLoader  # type: ignore
 import os
@@ -153,6 +154,7 @@ app.register_blueprint(admin_bp, url_prefix="/admin")
 app.register_blueprint(task_bp, url_prefix="/task")
 app.register_blueprint(schedule_bp)
 app.register_blueprint(public_bp)
+app.register_blueprint(booking_api, url_prefix="/api")
 
 
 @app.before_request

--- a/routes/booking_api.py
+++ b/routes/booking_api.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, request, jsonify
+from services import availability, booking
+
+booking_api = Blueprint("booking_api", __name__)
+
+
+@booking_api.route("/availability", methods=["GET"])
+def get_availability():
+    """Return availability filtered by optional service and date parameters."""
+    service_id = request.args.get("service_id")
+    date = request.args.get("date")
+    slots = availability.get_availability(service_id=service_id, date=date)
+    return jsonify(slots)
+
+
+@booking_api.route("/booking", methods=["POST"])
+def create_booking_route():
+    """Create a new booking using provided JSON payload."""
+    data = request.get_json() or {}
+    required = {"freelancer_id", "cliente_id", "data_ora", "servizi"}
+    if not required.issubset(data):
+        return jsonify({"error": "Dati mancanti"}), 400
+    result = booking.create_booking(data)
+    return jsonify(result), 201

--- a/services/availability.py
+++ b/services/availability.py
@@ -1,0 +1,19 @@
+from flask import g
+from typing import List, Dict, Optional
+
+
+def get_availability(service_id: Optional[str] = None, date: Optional[str] = None) -> List[Dict]:
+    """Return available slots optionally filtered by service and date.
+
+    Parameters
+    ----------
+    service_id: optional id of the service to filter on.
+    date: optional ISO date string to filter on (YYYY-MM-DD).
+    """
+    query = g.db.collection("disponibilita")
+    if service_id:
+        query = query.where("servizio_id", "==", service_id)
+    if date:
+        query = query.where("data", "==", date)
+    disp_docs = query.order_by("data_ora").stream()
+    return [{**doc.to_dict(), "id": doc.id} for doc in disp_docs]

--- a/services/booking.py
+++ b/services/booking.py
@@ -1,0 +1,31 @@
+import logging
+from flask import g
+from services.calendar import add_event
+
+logger = logging.getLogger(__name__)
+
+
+def create_booking(data: dict) -> dict:
+    """Persist a booking request and sync with the calendar if possible."""
+    g.db.collection("appuntamenti").add(
+        {
+            "freelancer_id": data["freelancer_id"],
+            "cliente_id": data["cliente_id"],
+            "data_ora": data["data_ora"],
+            "servizi": data["servizi"],
+            "stato": "richiesta",
+        }
+    )
+    try:
+        add_event(
+            g.db,
+            data["freelancer_id"],
+            {
+                "summary": f"Richiesta servizi {', '.join(data['servizi'])}",
+                "start": {"dateTime": data["data_ora"]},
+                "end": {"dateTime": data["data_ora"]},
+            },
+        )
+    except Exception as e:  # pragma: no cover - log but do not fail
+        logger.warning("Impossibile sincronizzare evento calendario: %s", e)
+    return {"success": True}


### PR DESCRIPTION
## Summary
- add availability and booking services
- expose booking API routes
- register booking API blueprint

## Testing
- `python -m py_compile services/availability.py services/booking.py routes/booking_api.py main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49898526c8330824d7a541d104d22