### PR TITLE
Refactor booking workflow

### DIFF
--- a/routes/booking_api.py
+++ b/routes/booking_api.py
@@ -15,10 +15,10 @@ def get_availability():
 
 @booking_api.route("/booking", methods=["POST"])
 def create_booking_route():
-    """Create a new booking using provided JSON payload."""
+    """Create a new booking using the provided JSON payload."""
     data = request.get_json() or {}
-    required = {"freelancer_id", "cliente_id", "data_ora", "servizi"}
+    required = {"tenant_id", "staff_id", "resource_id", "start_utc", "end_utc"}
     if not required.issubset(data):
-        return jsonify({"error": "Dati mancanti"}), 400
+        return jsonify({"error": "Missing required fields"}), 400
     result = booking.create_booking(data)
     return jsonify(result), 201


### PR DESCRIPTION
## Summary
- standardize booking API with unified field names and validation
- persist bookings via Firestore and sync calendar
- generate ICS feeds using start/end UTC and updated logging

## Testing
- `python -m py_compile routes/booking_api.py routes/booking_bp.py services/booking.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a593d645e4833090dbb1712092bd49